### PR TITLE
Support null safety

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,0 +1,62 @@
+name: Dart CI
+
+on:
+  # Run on PRs and pushes to the default branch.
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  # Check code formatting and static analysis on a single OS (linux)
+  # against Dart dev.
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [dev]
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{ matrix.sdk }}
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+        if: always() && steps.install.outcome == 'success'
+      - name: Analyze code
+        run: dart analyze --fatal-infos
+        if: always() && steps.install.outcome == 'success'
+
+  # Run tests on a matrix consisting of two dimensions:
+  # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
+  # 2. release channel: dev
+  test:
+    needs: analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add macos-latest and/or windows-latest if relevant for this package.
+        os: [ubuntu-latest]
+        # Bump SDK for Legacy tets when changning min SDK.
+        sdk: [2.18.0, dev]
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
+        with:
+          sdk: ${{ matrix.sdk }}
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Run tests
+        run: dart test -p chrome,vm --test-randomize-ordering-seed=random
+        if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -48,7 +48,7 @@ jobs:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
         # Bump SDK for Legacy tets when changning min SDK.
-        sdk: [2.18.0, dev]
+        sdk: [2.19.0, dev]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.1.7-dev
+## 0.2.0
+
+- Emit null safe dart with a `2.12` language version marker.
 
 ## 0.1.6
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
 linter:
   rules:
-    - prefer_final_locals
+    prefer_final_locals: true

--- a/example/messages.dart
+++ b/example/messages.dart
@@ -1,25 +1,36 @@
+// @dart=2.12
 class SomeMessage {
-  SomeMessage._(this.intField, this.stringField);
+  SomeMessage._(
+    this.intField,
+    this.stringField,
+  );
 
   factory SomeMessage(void Function(SomeMessage$Builder) init) {
     final b = SomeMessage$Builder._();
     init(b);
-    return SomeMessage._(b.intField, b.stringField);
+    return SomeMessage._(
+      b.intField,
+      b.stringField,
+    );
   }
 
   factory SomeMessage.fromJson(Map params) => SomeMessage._(
-      params.containsKey('intField') && params['intField'] != null
-          ? (params['intField'] as int)
-          : null,
-      params.containsKey('stringField') && params['stringField'] != null
-          ? (params['stringField'] as String)
-          : null);
+        params.containsKey('intField') && params['intField'] != null
+            ? (params['intField'] as int?)
+            : null,
+        params.containsKey('stringField') && params['stringField'] != null
+            ? (params['stringField'] as String?)
+            : null,
+      );
 
-  final int intField;
+  final int? intField;
 
-  final String stringField;
+  final String? stringField;
 
-  Map toJson() => {'intField': intField, 'stringField': stringField};
+  Map toJson() => {
+        'intField': intField,
+        'stringField': stringField,
+      };
   @override
   int get hashCode {
     var hash = 530289568;
@@ -38,9 +49,9 @@ class SomeMessage {
 class SomeMessage$Builder {
   SomeMessage$Builder._();
 
-  int intField;
+  int? intField;
 
-  String stringField;
+  String? stringField;
 }
 
 int _hashCombine(int hash, int value) {
@@ -63,7 +74,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/example/messages.dart
+++ b/example/messages.dart
@@ -31,6 +31,7 @@ class SomeMessage {
         'intField': intField,
         'stringField': stringField,
       };
+
   @override
   int get hashCode {
     var hash = 530289568;

--- a/lib/message_builder.dart
+++ b/lib/message_builder.dart
@@ -42,10 +42,9 @@ class MessageBuilder implements Builder {
     final library = Library((b) => b.body.addAll(result));
     final emitter = DartEmitter(
         allocator: Allocator.simplePrefixing(), useNullSafetySyntax: true);
+    final content = DartFormatter().format(library.accept(emitter).toString());
     await buildStep.writeAsString(
-        buildStep.inputId.changeExtension('.dart'),
-        '// @dart=2.12\n' +
-            DartFormatter().format('${library.accept(emitter)}'));
+        buildStep.inputId.changeExtension('.dart'), '// @dart=2.12\n$content');
   }
 }
 

--- a/lib/message_builder.dart
+++ b/lib/message_builder.dart
@@ -40,9 +40,12 @@ class MessageBuilder implements Builder {
       if (hasCollection) _deepEquals,
     ];
     final library = Library((b) => b.body.addAll(result));
-    final emitter = DartEmitter(Allocator.simplePrefixing());
-    await buildStep.writeAsString(buildStep.inputId.changeExtension('.dart'),
-        DartFormatter().format('${library.accept(emitter)}'));
+    final emitter = DartEmitter(
+        allocator: Allocator.simplePrefixing(), useNullSafetySyntax: true);
+    await buildStep.writeAsString(
+        buildStep.inputId.changeExtension('.dart'),
+        '// @dart=2.12\n' +
+            DartFormatter().format('${library.accept(emitter)}'));
   }
 }
 

--- a/lib/src/hash_code.dart
+++ b/lib/src/hash_code.dart
@@ -14,7 +14,9 @@ Method buildHashCode(String name, Iterable<MessageField> fields) {
       ..lambda = true
       ..body = literalNum(base).code);
   }
-  final statements = <Code>[literalNum(base).assignVar('hash').statement];
+  final statements = <Code>[
+    declareVar('hash').assign(literalNum(base)).statement
+  ];
   statements.addAll(fields.map((field) =>
       Code('hash = _hashCombine(hash, _deepHashCode(${field.name}));')));
   statements.add(Code('return _hashComplete(hash);'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 homepage: https://github.com/natebosch/message_builder
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   build: ^2.3.0
@@ -18,5 +18,5 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
   path: ^1.5.0
-  lints: ^2.1.0
+  lints: ">=1.0.0 <3.0.0" #^2.1.0
   test: ^1.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,22 +1,22 @@
 name: message_builder
-version: 0.1.7-dev
+version: 0.2.0
 description: >-
   Generate immutable Dart classes serializable to json from a schema.
 homepage: https://github.com/natebosch/message_builder
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  build: ^1.1.0
-  build_config: ^0.4.0
-  code_builder: ^3.1.0
-  dart_style: ^1.1.0
-  yaml: ^2.1.0
+  build: ^2.3.0
+  build_config: ^1.0.0
+  code_builder: ^4.6.0
+  dart_style: ^2.2.3
+  yaml: ^3.1.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_test: ^1.0.0
+  build_runner: ^2.0.0
+  build_test: ^2.0.0
   path: ^1.5.0
-  pedantic: ^1.9.0
+  lints: ^2.1.0
   test: ^1.13.0

--- a/test/goldens/enum.dart
+++ b/test/goldens/enum.dart
@@ -16,6 +16,7 @@ class MessageUsingEnum {
   final SomeEnum? enumField;
 
   Map toJson() => {'enumField': enumField?.toJson()};
+
   @override
   int get hashCode {
     var hash = 819494400;

--- a/test/goldens/enum.dart
+++ b/test/goldens/enum.dart
@@ -1,3 +1,4 @@
+// @dart=2.12
 class MessageUsingEnum {
   MessageUsingEnum._(this.enumField);
 
@@ -12,7 +13,7 @@ class MessageUsingEnum {
           ? SomeEnum.fromJson((params['enumField'] as int))
           : null);
 
-  final SomeEnum enumField;
+  final SomeEnum? enumField;
 
   Map toJson() => {'enumField': enumField?.toJson()};
   @override
@@ -30,13 +31,18 @@ class MessageUsingEnum {
 class MessageUsingEnum$Builder {
   MessageUsingEnum$Builder._();
 
-  SomeEnum enumField;
+  SomeEnum? enumField;
 }
 
 class SomeEnum {
   factory SomeEnum.fromJson(int value) {
-    const values = {2: SomeEnum.anotherValue, 1: SomeEnum.someValue};
-    return values[value];
+    const values = {
+      2: SomeEnum.anotherValue,
+      1: SomeEnum.someValue,
+    };
+    return values[value] ??
+        (throw FormatException(
+            '$value is not a valid wire value for SomeEnum'));
   }
 
   const SomeEnum._(this._value);
@@ -70,7 +76,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/list_field.dart
+++ b/test/goldens/list_field.dart
@@ -1,25 +1,36 @@
+// @dart=2.12
 class SomeListMessage {
-  SomeListMessage._(this.intList, this.stringList);
+  SomeListMessage._(
+    this.intList,
+    this.stringList,
+  );
 
   factory SomeListMessage(void Function(SomeListMessage$Builder) init) {
     final b = SomeListMessage$Builder._();
     init(b);
-    return SomeListMessage._(b.intList, b.stringList);
+    return SomeListMessage._(
+      b.intList,
+      b.stringList,
+    );
   }
 
   factory SomeListMessage.fromJson(Map params) => SomeListMessage._(
-      params.containsKey('intList') && params['intList'] != null
-          ? (params['intList'] as List).cast<int>()
-          : null,
-      params.containsKey('stringList') && params['stringList'] != null
-          ? (params['stringList'] as List).cast<String>()
-          : null);
+        params.containsKey('intList') && params['intList'] != null
+            ? (params['intList'] as List).cast<int?>()
+            : null,
+        params.containsKey('stringList') && params['stringList'] != null
+            ? (params['stringList'] as List).cast<String?>()
+            : null,
+      );
 
-  final List<int> intList;
+  final List<int?>? intList;
 
-  final List<String> stringList;
+  final List<String?>? stringList;
 
-  Map toJson() => {'intList': intList, 'stringList': stringList};
+  Map toJson() => {
+        'intList': intList,
+        'stringList': stringList,
+      };
   @override
   int get hashCode {
     var hash = 530163;
@@ -31,16 +42,22 @@ class SomeListMessage {
   @override
   bool operator ==(Object other) =>
       other is SomeListMessage &&
-      _deepEquals(intList, other.intList) &&
-      _deepEquals(stringList, other.stringList);
+      _deepEquals(
+        intList,
+        other.intList,
+      ) &&
+      _deepEquals(
+        stringList,
+        other.stringList,
+      );
 }
 
 class SomeListMessage$Builder {
   SomeListMessage$Builder._();
 
-  List<int> intList;
+  List<int?>? intList;
 
-  List<String> stringList;
+  List<String?>? stringList;
 }
 
 int _hashCombine(int hash, int value) {
@@ -63,7 +80,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/list_field.dart
+++ b/test/goldens/list_field.dart
@@ -31,6 +31,7 @@ class SomeListMessage {
         'intList': intList,
         'stringList': stringList,
       };
+
   @override
   int get hashCode {
     var hash = 530163;

--- a/test/goldens/map_field.dart
+++ b/test/goldens/map_field.dart
@@ -16,6 +16,7 @@ class AnotherMessage {
   final Map<String, String?>? innerMessageMap;
 
   Map toJson() => {'innerMessageMap': innerMessageMap};
+
   @override
   int get hashCode {
     var hash = 170180962;
@@ -114,6 +115,7 @@ class SomeMapMessage {
               v?.toJson(),
             )),
       };
+
   @override
   int get hashCode {
     var hash = 1073311120;

--- a/test/goldens/map_field.dart
+++ b/test/goldens/map_field.dart
@@ -1,3 +1,4 @@
+// @dart=2.12
 class AnotherMessage {
   AnotherMessage._(this.innerMessageMap);
 
@@ -9,10 +10,10 @@ class AnotherMessage {
 
   factory AnotherMessage.fromJson(Map params) => AnotherMessage._(
       params.containsKey('innerMessageMap') && params['innerMessageMap'] != null
-          ? (params['innerMessageMap'] as Map).cast<String, String>()
+          ? (params['innerMessageMap'] as Map).cast<String, String?>()
           : null);
 
-  final Map<String, String> innerMessageMap;
+  final Map<String, String?>? innerMessageMap;
 
   Map toJson() => {'innerMessageMap': innerMessageMap};
   @override
@@ -25,58 +26,93 @@ class AnotherMessage {
   @override
   bool operator ==(Object other) =>
       other is AnotherMessage &&
-      _deepEquals(innerMessageMap, other.innerMessageMap);
+      _deepEquals(
+        innerMessageMap,
+        other.innerMessageMap,
+      );
 }
 
 class AnotherMessage$Builder {
   AnotherMessage$Builder._();
 
-  Map<String, String> innerMessageMap;
+  Map<String, String?>? innerMessageMap;
 }
 
 class SomeMapMessage {
-  SomeMapMessage._(this.intMap, this.listMap, this.mapMap, this.messageMap);
+  SomeMapMessage._(
+    this.intMap,
+    this.listMap,
+    this.mapMap,
+    this.messageMap,
+  );
 
   factory SomeMapMessage(void Function(SomeMapMessage$Builder) init) {
     final b = SomeMapMessage$Builder._();
     init(b);
-    return SomeMapMessage._(b.intMap, b.listMap, b.mapMap, b.messageMap);
+    return SomeMapMessage._(
+      b.intMap,
+      b.listMap,
+      b.mapMap,
+      b.messageMap,
+    );
   }
 
   factory SomeMapMessage.fromJson(Map params) => SomeMapMessage._(
-      params.containsKey('intMap') && params['intMap'] != null
-          ? (params['intMap'] as Map).cast<String, int>()
-          : null,
-      params.containsKey('listMap') && params['listMap'] != null
-          ? (params['listMap'] as Map).map((k, v) =>
-              MapEntry<String, List<int>>(
-                  (k as String), (v as List).cast<int>()))
-          : null,
-      params.containsKey('mapMap') && params['mapMap'] != null
-          ? (params['mapMap'] as Map).map((k, v) =>
-              MapEntry<String, Map<String, String>>(
-                  (k as String), (v as Map).cast<String, String>()))
-          : null,
-      params.containsKey('messageMap') && params['messageMap'] != null
-          ? (params['messageMap'] as Map).map((k, v) =>
-              MapEntry<String, AnotherMessage>(
-                  (k as String), AnotherMessage.fromJson((v as Map))))
-          : null);
+        params.containsKey('intMap') && params['intMap'] != null
+            ? (params['intMap'] as Map).cast<String, int?>()
+            : null,
+        params.containsKey('listMap') && params['listMap'] != null
+            ? (params['listMap'] as Map).map((
+                k,
+                v,
+              ) =>
+                MapEntry<String, List<int?>?>(
+                  (k as String),
+                  (v as List).cast<int?>(),
+                ))
+            : null,
+        params.containsKey('mapMap') && params['mapMap'] != null
+            ? (params['mapMap'] as Map).map((
+                k,
+                v,
+              ) =>
+                MapEntry<String, Map<String, String?>?>(
+                  (k as String),
+                  (v as Map).cast<String, String?>(),
+                ))
+            : null,
+        params.containsKey('messageMap') && params['messageMap'] != null
+            ? (params['messageMap'] as Map).map((
+                k,
+                v,
+              ) =>
+                MapEntry<String, AnotherMessage?>(
+                  (k as String),
+                  AnotherMessage.fromJson((v as Map)),
+                ))
+            : null,
+      );
 
-  final Map<String, int> intMap;
+  final Map<String, int?>? intMap;
 
-  final Map<String, List<int>> listMap;
+  final Map<String, List<int?>?>? listMap;
 
-  final Map<String, Map<String, String>> mapMap;
+  final Map<String, Map<String, String?>?>? mapMap;
 
-  final Map<String, AnotherMessage> messageMap;
+  final Map<String, AnotherMessage?>? messageMap;
 
   Map toJson() => {
         'intMap': intMap,
         'listMap': listMap,
         'mapMap': mapMap,
-        'messageMap':
-            messageMap?.map((k, v) => MapEntry<String, dynamic>(k, v?.toJson()))
+        'messageMap': messageMap?.map((
+          k,
+          v,
+        ) =>
+            MapEntry<String, dynamic>(
+              k,
+              v?.toJson(),
+            )),
       };
   @override
   int get hashCode {
@@ -91,22 +127,34 @@ class SomeMapMessage {
   @override
   bool operator ==(Object other) =>
       other is SomeMapMessage &&
-      _deepEquals(intMap, other.intMap) &&
-      _deepEquals(listMap, other.listMap) &&
-      _deepEquals(mapMap, other.mapMap) &&
-      _deepEquals(messageMap, other.messageMap);
+      _deepEquals(
+        intMap,
+        other.intMap,
+      ) &&
+      _deepEquals(
+        listMap,
+        other.listMap,
+      ) &&
+      _deepEquals(
+        mapMap,
+        other.mapMap,
+      ) &&
+      _deepEquals(
+        messageMap,
+        other.messageMap,
+      );
 }
 
 class SomeMapMessage$Builder {
   SomeMapMessage$Builder._();
 
-  Map<String, int> intMap;
+  Map<String, int?>? intMap;
 
-  Map<String, List<int>> listMap;
+  Map<String, List<int?>?>? listMap;
 
-  Map<String, Map<String, String>> mapMap;
+  Map<String, Map<String, String?>?>? mapMap;
 
-  Map<String, AnotherMessage> messageMap;
+  Map<String, AnotherMessage?>? messageMap;
 }
 
 int _hashCombine(int hash, int value) {
@@ -129,7 +177,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/message.dart
+++ b/test/goldens/message.dart
@@ -1,25 +1,36 @@
+// @dart=2.12
 class SomeMessage {
-  SomeMessage._(this.intField, this.stringField);
+  SomeMessage._(
+    this.intField,
+    this.stringField,
+  );
 
   factory SomeMessage(void Function(SomeMessage$Builder) init) {
     final b = SomeMessage$Builder._();
     init(b);
-    return SomeMessage._(b.intField, b.stringField);
+    return SomeMessage._(
+      b.intField,
+      b.stringField,
+    );
   }
 
   factory SomeMessage.fromJson(Map params) => SomeMessage._(
-      params.containsKey('intField') && params['intField'] != null
-          ? (params['intField'] as int)
-          : null,
-      params.containsKey('stringField') && params['stringField'] != null
-          ? (params['stringField'] as String)
-          : null);
+        params.containsKey('intField') && params['intField'] != null
+            ? (params['intField'] as int?)
+            : null,
+        params.containsKey('stringField') && params['stringField'] != null
+            ? (params['stringField'] as String?)
+            : null,
+      );
 
-  final int intField;
+  final int? intField;
 
-  final String stringField;
+  final String? stringField;
 
-  Map toJson() => {'intField': intField, 'stringField': stringField};
+  Map toJson() => {
+        'intField': intField,
+        'stringField': stringField,
+      };
   @override
   int get hashCode {
     var hash = 530289568;
@@ -38,9 +49,9 @@ class SomeMessage {
 class SomeMessage$Builder {
   SomeMessage$Builder._();
 
-  int intField;
+  int? intField;
 
-  String stringField;
+  String? stringField;
 }
 
 int _hashCombine(int hash, int value) {
@@ -63,7 +74,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/message.dart
+++ b/test/goldens/message.dart
@@ -31,6 +31,7 @@ class SomeMessage {
         'intField': intField,
         'stringField': stringField,
       };
+
   @override
   int get hashCode {
     var hash = 530289568;

--- a/test/goldens/nested_in_list.dart
+++ b/test/goldens/nested_in_list.dart
@@ -1,3 +1,4 @@
+// @dart=2.12
 class InnerMessageInList {
   InnerMessageInList._(this.anotherField);
 
@@ -9,10 +10,10 @@ class InnerMessageInList {
 
   factory InnerMessageInList.fromJson(Map params) => InnerMessageInList._(
       params.containsKey('anotherField') && params['anotherField'] != null
-          ? (params['anotherField'] as String)
+          ? (params['anotherField'] as String?)
           : null);
 
-  final String anotherField;
+  final String? anotherField;
 
   Map toJson() => {'anotherField': anotherField};
   @override
@@ -30,7 +31,7 @@ class InnerMessageInList {
 class InnerMessageInList$Builder {
   InnerMessageInList$Builder._();
 
-  String anotherField;
+  String? anotherField;
 }
 
 class OuterMessageWithList {
@@ -50,9 +51,9 @@ class OuterMessageWithList {
               .toList()
           : null);
 
-  final List<InnerMessageInList> innerField;
+  final List<InnerMessageInList?>? innerField;
 
-  Map toJson() => {'innerField': innerField?.map((v) => v?.toJson())?.toList()};
+  Map toJson() => {'innerField': innerField?.map((v) => v?.toJson()).toList()};
   @override
   int get hashCode {
     var hash = 248509690;
@@ -63,13 +64,16 @@ class OuterMessageWithList {
   @override
   bool operator ==(Object other) =>
       other is OuterMessageWithList &&
-      _deepEquals(innerField, other.innerField);
+      _deepEquals(
+        innerField,
+        other.innerField,
+      );
 }
 
 class OuterMessageWithList$Builder {
   OuterMessageWithList$Builder._();
 
-  List<InnerMessageInList> innerField;
+  List<InnerMessageInList?>? innerField;
 }
 
 int _hashCombine(int hash, int value) {
@@ -92,7 +96,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/nested_in_list.dart
+++ b/test/goldens/nested_in_list.dart
@@ -16,6 +16,7 @@ class InnerMessageInList {
   final String? anotherField;
 
   Map toJson() => {'anotherField': anotherField};
+
   @override
   int get hashCode {
     var hash = 620164184;
@@ -54,6 +55,7 @@ class OuterMessageWithList {
   final List<InnerMessageInList?>? innerField;
 
   Map toJson() => {'innerField': innerField?.map((v) => v?.toJson()).toList()};
+
   @override
   int get hashCode {
     var hash = 248509690;

--- a/test/goldens/nested_message.dart
+++ b/test/goldens/nested_message.dart
@@ -1,3 +1,4 @@
+// @dart=2.12
 class InnerMessage {
   InnerMessage._(this.anotherField);
 
@@ -9,10 +10,10 @@ class InnerMessage {
 
   factory InnerMessage.fromJson(Map params) => InnerMessage._(
       params.containsKey('anotherField') && params['anotherField'] != null
-          ? (params['anotherField'] as String)
+          ? (params['anotherField'] as String?)
           : null);
 
-  final String anotherField;
+  final String? anotherField;
 
   Map toJson() => {'anotherField': anotherField};
   @override
@@ -30,32 +31,41 @@ class InnerMessage {
 class InnerMessage$Builder {
   InnerMessage$Builder._();
 
-  String anotherField;
+  String? anotherField;
 }
 
 class OuterMessage {
-  OuterMessage._(this.innerField, this.stringField);
+  OuterMessage._(
+    this.innerField,
+    this.stringField,
+  );
 
   factory OuterMessage(void Function(OuterMessage$Builder) init) {
     final b = OuterMessage$Builder._();
     init(b);
-    return OuterMessage._(b.innerField, b.stringField);
+    return OuterMessage._(
+      b.innerField,
+      b.stringField,
+    );
   }
 
   factory OuterMessage.fromJson(Map params) => OuterMessage._(
-      params.containsKey('innerField') && params['innerField'] != null
-          ? InnerMessage.fromJson((params['innerField'] as Map))
-          : null,
-      params.containsKey('stringField') && params['stringField'] != null
-          ? (params['stringField'] as String)
-          : null);
+        params.containsKey('innerField') && params['innerField'] != null
+            ? InnerMessage.fromJson((params['innerField'] as Map))
+            : null,
+        params.containsKey('stringField') && params['stringField'] != null
+            ? (params['stringField'] as String?)
+            : null,
+      );
 
-  final InnerMessage innerField;
+  final InnerMessage? innerField;
 
-  final String stringField;
+  final String? stringField;
 
-  Map toJson() =>
-      {'innerField': innerField?.toJson(), 'stringField': stringField};
+  Map toJson() => {
+        'innerField': innerField?.toJson(),
+        'stringField': stringField,
+      };
   @override
   int get hashCode {
     var hash = 556777058;
@@ -74,9 +84,9 @@ class OuterMessage {
 class OuterMessage$Builder {
   OuterMessage$Builder._();
 
-  InnerMessage innerField;
+  InnerMessage? innerField;
 
-  String stringField;
+  String? stringField;
 }
 
 int _hashCombine(int hash, int value) {
@@ -99,7 +109,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/nested_message.dart
+++ b/test/goldens/nested_message.dart
@@ -16,6 +16,7 @@ class InnerMessage {
   final String? anotherField;
 
   Map toJson() => {'anotherField': anotherField};
+
   @override
   int get hashCode {
     var hash = 407157155;
@@ -66,6 +67,7 @@ class OuterMessage {
         'innerField': innerField?.toJson(),
         'stringField': stringField,
       };
+
   @override
   int get hashCode {
     var hash = 556777058;

--- a/test/goldens/subclassed_message.dart
+++ b/test/goldens/subclassed_message.dart
@@ -1,3 +1,4 @@
+// @dart=2.12
 abstract class ParentMessage {
   factory ParentMessage.fromJson(Map params) {
     final selectBy = params['selectField'];
@@ -21,15 +22,18 @@ class FirstChildMessage implements ParentMessage {
 
   factory FirstChildMessage.fromJson(Map params) => FirstChildMessage._(
       params.containsKey('firstField') && params['firstField'] != null
-          ? (params['firstField'] as int)
+          ? (params['firstField'] as int?)
           : null);
 
-  final int firstField;
+  final int? firstField;
 
   final selectField = 'firstValue';
 
   @override
-  Map toJson() => {'firstField': firstField, 'selectField': 'firstValue'};
+  Map toJson() => {
+        'firstField': firstField,
+        'selectField': 'firstValue',
+      };
   @override
   int get hashCode {
     var hash = 307866602;
@@ -45,7 +49,7 @@ class FirstChildMessage implements ParentMessage {
 class FirstChildMessage$Builder {
   FirstChildMessage$Builder._();
 
-  int firstField;
+  int? firstField;
 }
 
 class SecondChildMessage implements ParentMessage {
@@ -59,15 +63,18 @@ class SecondChildMessage implements ParentMessage {
 
   factory SecondChildMessage.fromJson(Map params) => SecondChildMessage._(
       params.containsKey('secondField') && params['secondField'] != null
-          ? (params['secondField'] as String)
+          ? (params['secondField'] as String?)
           : null);
 
-  final String secondField;
+  final String? secondField;
 
   final selectField = 'secondValue';
 
   @override
-  Map toJson() => {'secondField': secondField, 'selectField': 'secondValue'};
+  Map toJson() => {
+        'secondField': secondField,
+        'selectField': 'secondValue',
+      };
   @override
   int get hashCode {
     var hash = 34131136;
@@ -83,7 +90,7 @@ class SecondChildMessage implements ParentMessage {
 class SecondChildMessage$Builder {
   SecondChildMessage$Builder._();
 
-  String secondField;
+  String? secondField;
 }
 
 class ThirdChildMessage implements ParentMessage {
@@ -125,7 +132,7 @@ int _deepHashCode(dynamic value) {
     return (value.keys
             .map((key) => _hashCombine(key.hashCode, _deepHashCode(value[key])))
             .toList(growable: false)
-              ..sort())
+          ..sort())
         .reduce(_hashCombine);
   }
   return value.hashCode;

--- a/test/goldens/subclassed_message.dart
+++ b/test/goldens/subclassed_message.dart
@@ -34,6 +34,7 @@ class FirstChildMessage implements ParentMessage {
         'firstField': firstField,
         'selectField': 'firstValue',
       };
+
   @override
   int get hashCode {
     var hash = 307866602;
@@ -75,6 +76,7 @@ class SecondChildMessage implements ParentMessage {
         'secondField': secondField,
         'selectField': 'secondValue',
       };
+
   @override
   int get hashCode {
     var hash = 34131136;
@@ -102,8 +104,10 @@ class ThirdChildMessage implements ParentMessage {
 
   @override
   Map toJson() => {'selectField': 'thirdValue'};
+
   @override
   int get hashCode => 560423767;
+
   @override
   bool operator ==(Object other) => other is ThirdChildMessage;
 }

--- a/test/message_builder_golden_test.dart
+++ b/test/message_builder_golden_test.dart
@@ -1,3 +1,4 @@
+@TestOn('vm')
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/message_builder_golden_test.dart
+++ b/test/message_builder_golden_test.dart
@@ -13,11 +13,11 @@ void main() {
     final goldenDir = Directory('test/goldens/');
     for (final item in goldenDir.listSync()) {
       if (!item.path.endsWith('.yaml') || item is! File) continue;
-      final file = item as File;
+      final file = item;
       test(p.basename(file.path), () {
         final yamlContent = file.readAsStringSync();
         final dartFile =
-            File(file.path.substring(0, file.path.length - 4) + 'dart');
+            File('${file.path.substring(0, file.path.length - 4)}dart');
         final dartContent = dartFile.readAsStringSync();
         return testBuilder(builder, {
           'a|${p.basename(file.path)}': yamlContent


### PR DESCRIPTION
Not yet migrating to Dart 3. Incremental update to null safe Dart. All fields are nullable, without the option to specify non-null.

- Update dependencies to null safe versions.
- Migrate local code to null safety.
- Require latest code_builder to pick up `parenthesized`.
- Emit with `// @Dart=2.12` comments since it may not emit Dart 3 compatible code.
- Make all field types use nullable references.

Cleanup:
- Change some `assignConst` and `assignFinal` to `declareConst` and `declareFinal` to resolve deprecations.
- Update to `package:lints`